### PR TITLE
Allow to add quotes in options content

### DIFF
--- a/src/main/java/io/github/ved/jrequester/OptionData.java
+++ b/src/main/java/io/github/ved/jrequester/OptionData.java
@@ -50,7 +50,7 @@ public class OptionData {
 				this.content = optionContent;
 			}
 			else{
-				this.content = optionContent.substring(1, optionContent.length() - 1).replaceAll("\\" + wrapper, wrapper);
+				this.content = optionContent.substring(1, optionContent.length() - 1).replaceAll("\\\\" + wrapper, wrapper);
 			}
 			
 		}

--- a/src/main/java/io/github/ved/jrequester/OptionData.java
+++ b/src/main/java/io/github/ved/jrequester/OptionData.java
@@ -31,10 +31,30 @@ public class OptionData {
 	}
 	
 	protected void setContent(String optionContent){
-		if(optionContent == null)
+		
+		if(optionContent == null){
 			this.content = null;
-		else
-			this.content = optionContent.replaceAll("\"", "");
+		}
+		else{
+			
+			String wrapper = null;
+			
+			if(optionContent.matches("^\".*\"$")){
+				wrapper = "\"";
+			}
+			else if(optionContent.matches("^'.*'$")){
+				wrapper = "'";
+			}
+			
+			if(wrapper == null){
+				this.content = optionContent;
+			}
+			else{
+				this.content = optionContent.substring(1, optionContent.length() - 1).replaceAll("\\" + wrapper, wrapper);
+			}
+			
+		}
+		
 	}
 	
 	public int getPosition(){

--- a/src/main/java/io/github/ved/jrequester/Utils.java
+++ b/src/main/java/io/github/ved/jrequester/Utils.java
@@ -9,7 +9,7 @@ public interface Utils {
 	
 	static List<String> splitSpacesExcludeQuotes(String string){
 		List<String> possibleStrings = new ArrayList<>();
-		Matcher matcher = Pattern.compile("[^\\s\"']+|\"([^\"]*)\"|'([^']*)'")
+		Matcher matcher = Pattern.compile("[^\\s\"']+|\"(?!\\\").*\"|'(?!\\').*'")
 				.matcher(string);
 		while(matcher.find()){
 			possibleStrings.add(matcher.group());

--- a/src/test/java/io/github/ved/jrequester/RequestTest.java
+++ b/src/test/java/io/github/ved/jrequester/RequestTest.java
@@ -157,7 +157,7 @@ public class RequestTest {
 		
 		assertEquals("option", requestOption.getOptionName());
 		assertEquals("hi!", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -170,7 +170,7 @@ public class RequestTest {
 		
 		assertEquals("option", requestOption.getOptionName());
 		assertEquals("hello there!", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -183,7 +183,7 @@ public class RequestTest {
 		
 		assertEquals("o", requestOption.getOptionName());
 		assertEquals("hi!", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -196,7 +196,7 @@ public class RequestTest {
 		
 		assertEquals("o", requestOption.getOptionName());
 		assertEquals("hello there!", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -209,7 +209,7 @@ public class RequestTest {
 		
 		assertEquals("option", requestOption.getOptionName());
 		assertEquals("test \" quote", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -222,7 +222,7 @@ public class RequestTest {
 		
 		assertEquals("o", requestOption.getOptionName());
 		assertEquals("test \" quote", requestOption.getContent());
-		assertEquals(1, requestOption.getPosition());
+		assertEquals(0, requestOption.getPosition());
 	
 	}
 	
@@ -235,13 +235,13 @@ public class RequestTest {
 		
 		assertEquals("o", requestOption.getOptionName());
 		assertEquals("hi!", requestOption.getContent());
-		assertEquals(4, requestOption.getPosition());
+		assertEquals(3, requestOption.getPosition());
 		
 		OptionData requestOption2 = request.getOption("b");
 		
 		assertEquals("b", requestOption2.getOptionName());
 		assertNull(requestOption2.getContent());
-		assertEquals(2, requestOption2.getPosition());
+		assertEquals(1, requestOption2.getPosition());
 	
 	}
 	

--- a/src/test/java/io/github/ved/jrequester/RequestTest.java
+++ b/src/test/java/io/github/ved/jrequester/RequestTest.java
@@ -2,6 +2,7 @@ package io.github.ved.jrequester;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +146,103 @@ public class RequestTest {
 		assertEquals(prefix, testRequest.getCommandPrefix());
 		assertEquals("test", testRequest.getCommand());
 		
+	}
+	
+	@Test
+	void createOptionData(){
+		
+		Request request = new Request("!hi --option hi!");
+		
+		OptionData requestOption = request.getOption("option");
+		
+		assertEquals("option", requestOption.getOptionName());
+		assertEquals("hi!", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createOptionDataWithSpace(){
+		
+		Request request = new Request("!hi --option \"hello there!\"");
+		
+		OptionData requestOption = request.getOption("option");
+		
+		assertEquals("option", requestOption.getOptionName());
+		assertEquals("hello there!", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createShortOptionData(){
+		
+		Request request = new Request("!hi -o hi!");
+		
+		OptionData requestOption = request.getOption("o");
+		
+		assertEquals("o", requestOption.getOptionName());
+		assertEquals("hi!", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createShortOptionDataWithSpace(){
+		
+		Request request = new Request("!hi -o \"hello there!\"");
+		
+		OptionData requestOption = request.getOption("o");
+		
+		assertEquals("o", requestOption.getOptionName());
+		assertEquals("hello there!", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createOptionDataWithProtectedQuote(){
+		
+		Request request = new Request("!hi --option \"test \\\" quote\"");
+		
+		OptionData requestOption = request.getOption("option");
+		
+		assertEquals("option", requestOption.getOptionName());
+		assertEquals("test \" quote", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createShortOptionDataWithProtectedQuote(){
+		
+		Request request = new Request("!hi -o \"test \\\" quote\"");
+		
+		OptionData requestOption = request.getOption("o");
+		
+		assertEquals("o", requestOption.getOptionName());
+		assertEquals("test \" quote", requestOption.getContent());
+		assertEquals(1, requestOption.getPosition());
+	
+	}
+	
+	@Test
+	void createMultipleShortOptionData(){
+		
+		Request request = new Request("!hi -abco hi!");
+		
+		OptionData requestOption = request.getOption("o");
+		
+		assertEquals("o", requestOption.getOptionName());
+		assertEquals("hi!", requestOption.getContent());
+		assertEquals(4, requestOption.getPosition());
+		
+		OptionData requestOption2 = request.getOption("b");
+		
+		assertEquals("b", requestOption2.getOptionName());
+		assertNull(requestOption2.getContent());
+		assertEquals(2, requestOption2.getPosition());
+	
 	}
 	
 }


### PR DESCRIPTION
I expect two test failures with createOptionDataWithProtectedQuote() and createShortOptionDataWithProtectedQuote() as you currently cannot escape quotes in a quoted option content, which would be a good idea to implement.

~~This PR will be renamed to "Allow to add quotes in options content" once the added tests will be fixed.~~